### PR TITLE
Create ServiceDiscovery in get_dependency().

### DIFF
--- a/src/nameko_chassis/dependencies.py
+++ b/src/nameko_chassis/dependencies.py
@@ -42,9 +42,6 @@ class ServiceDiscoveryProvider(DependencyProvider):
         self.username = username
         self.password = password
 
-    def setup(self):
-        self.client = Client(self.management_host, self.username, self.password)
-        self.discovery = ServiceDiscovery(self.client)
-
     def get_dependency(self, worker_ctx: WorkerContext) -> ServiceDiscovery:
-        return self.discovery
+        client = Client(self.management_host, self.username, self.password)
+        return ServiceDiscovery(client)


### PR DESCRIPTION
This will make sure that the pyrabbit client is local to the worker and
is not shared with other workers. It should fix the intermittent
eventlet error: `Second simultaneous read on fileno...`