### PR TITLE
Fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+sphinx:
+   configuration: docs/conf.py
+python:
+   install:
+     - method: pip
+       path: .
+     - requirements: docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include .bumpversion.cfg
 include .coveragerc
 include .cookiecutterrc
 include .editorconfig
+include .readthedocs.yaml
 include AUTHORS.rst
 include CHANGELOG.rst
 include CONTRIBUTING.rst

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
--r ../ci/requirements.txt
-sphinx>=1.3
-sphinx-rtd-theme
+sphinx>=4
+sphinx-rtd-theme>=1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=4
-sphinx-rtd-theme>=1
+sphinx>=4,<5
+sphinx-rtd-theme>=1,<2


### PR DESCRIPTION
This fixes installation of doc requirements and provides config file to avoid manual setup in RTD admin interface.