### PR TITLE
Add set_log_level() RPC method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
-
 Changelog
 =========
+
+0.9.0 (no release date yet)
+---------------------------
+
+* Add ``set_log_level()`` RPC method to dynamically change log level at
+  runtime for supported loggers.
 
 0.8.1 (2021-11-12)
 ------------------

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,3 +1,5 @@
+import logging
+
 from nameko.testing.services import worker_factory
 from nameko_prometheus.dependencies import MetricsServer
 from werkzeug.test import EnvironBuilder
@@ -22,3 +24,12 @@ def test_serve_metrics():
     service = worker_factory(MyService, metrics=MetricsServer())
     response = service.serve_metrics(request)
     assert response.status_code == 200
+
+
+def test_set_log_level():
+    service = worker_factory(MyService)
+    logger = logging.getLogger("foo.bar")
+    logger.setLevel(logging.ERROR)
+    service.set_log_level("foo.bar", logging.DEBUG)
+    logger = logging.getLogger("foo.bar")
+    assert logger.level == logging.DEBUG


### PR DESCRIPTION
Add ``set_log_level()`` RPC method to dynamically change log level at
  runtime for supported loggers.

Useful for example for debugging a live service instance, where your
default log level is INFO or higher to avoid clutter in logs. This
RPC allows you to change log level while the application is running.
