### PR TITLE
Add support for nameko 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,11 @@
 Changelog
 =========
 
-Unreleased
-----------
+1.0.0 (2022-07-20)
+------------------
 
+* *BREAKING CHANGE* Drop out-of-the-box Zipkin integration.
+* Add support for nameko 3.0 RC.
 * Add support for Python 3.10.
 * Drop support for Python 3.7. The minimum required version is now 3.8.
 

--- a/README.rst
+++ b/README.rst
@@ -59,15 +59,31 @@ observable microservices with the nameko_ framework.
 .. _nameko: https://www.nameko.io/
 
 
+Upcoming releases and distributed tracing
+=========================================
+
+We're aiming to add support for nameko 3.0 as soon as possible. However this
+will be a breaking change as we decided to drop Zipkin integration. Here's
+the plan:
+
+- 0.9.0 (current release) supports only nameko 2 and has Zipkin integration
+- 1.0 (upcoming) supports both nameko 2 and 3 RC, while dropping Zipkin. If
+  you need Zipkin support and your service is still on nameko 2, either stay on
+  nameko-chassis 0.9, or upgrade to 1.x and manage nameko-zipkin yourself.
+- In 2.0 we will only support nameko v3 and we intend to add OpenTelemetry
+  integration to base Service class. You can still use OpenTelemetry with
+  nameko-chassis 1.0 (provided you're using nameko 3), but before 2.0 you'll
+  need to set it up yourself.
+
+
 Features
 ========
 
 By using ``nameko_chassis.service.Service``, you'll get:
 
- - error reporting using Sentry
- - integrated metrics endpoint for Prometheus
- - request tracing with Zipkin
- - helpers for service discovery (TODO)
+- error reporting using Sentry
+- integrated metrics endpoint for Prometheus
+- helpers for service discovery
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -104,9 +104,7 @@ Base service class
        @rpc
        def my_method(self):
            try:
-               self.zipkin.update_binary_annotations({
-                  "foo": "bar",
-               })
+               do_something()
            except Exception:
                self.sentry.captureException()
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,9 +13,6 @@ ignore_missing_imports = True
 [mypy-nameko_sentry.*]
 ignore_missing_imports = True
 
-[mypy-nameko_zipkin.*]
-ignore_missing_imports = True
-
 [mypy-pyrabbit.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     },
     python_requires=">=3.8.*",
     install_requires=[
-        "nameko>=2,<3",
+        "nameko>=2,<4",
         "nameko-sentry>=1.0,<2",
         "nameko-prometheus>=1.0,<2",
         "pyrabbit>=1.1,<2",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     install_requires=[
         "nameko>=2,<3",
         "nameko-sentry>=1.0,<2",
-        "emplo-nameko-zipkin>=0.1.7",
         "nameko-prometheus>=1.0,<2",
         "pyrabbit>=1.1,<2",
         "werkzeug>=1.0,<3",

--- a/src/nameko_chassis/service.py
+++ b/src/nameko_chassis/service.py
@@ -14,7 +14,6 @@ from nameko.rpc import rpc
 from nameko.web.handlers import http
 from nameko_prometheus import PrometheusMetrics
 from nameko_sentry import SentryReporter
-from nameko_zipkin import Zipkin
 from werkzeug.wrappers import Request, Response
 
 from .dependencies import ContainerProvider, SentryLoggerConfig
@@ -96,7 +95,6 @@ class Service:
     sentry = SentryReporter()
     config = Config()
     container = ContainerProvider()
-    zipkin = Zipkin()
     metrics = PrometheusMetrics()
 
     @rpc

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,16 @@
 envlist =
     clean,
     check,
-    py{38,39,310},
+    py{38,39,310}-nameko{2,3},
     report
 
 [testenv]
 deps =
+    nameko2: nameko>=2.14,<3
+    nameko3: nameko>=3.0.0rc11,<4
     -r{toxinidir}/test_requirements.txt
 commands =
-    {posargs:pytest --cov={envsitepackagesdir}/nameko_chassis -vv}
+    {posargs:nameko test --cov={envsitepackagesdir}/nameko_chassis -vv}
 
 [testenv:check]
 deps =
@@ -40,6 +42,6 @@ deps = coverage
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
-    3.10: py310, clean, check, report
+    3.8: py38-nameko2, py38-nameko3
+    3.9: py39-nameko2, py39-nameko3
+    3.10: py310-nameko2, py310-nameko3, clean, check, report


### PR DESCRIPTION
Since we're not going to update emplo-nameko-zipkin for nameko 3, at this point in time we're dropping Zipkin integration. As per plan in readme, once we're v3-only, we'll add out of the box OpenTelemetry setup.