### PR TITLE
Fix obsolete import in is_service_responsive.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.0.1 (2022-09-01)
+------------------
+
+* Fix obsolete nameko 2 import in is_service_responsive.
+
 2.0.0 (2022-08-25)
 ------------------
 

--- a/src/nameko_chassis/health.py
+++ b/src/nameko_chassis/health.py
@@ -1,7 +1,7 @@
 import logging
 
 import eventlet
-from nameko.rpc import ServiceProxy
+from nameko.rpc import Client
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +11,7 @@ class ServiceTimeout(Exception):
 
 
 def is_service_responsive(
-    service_proxy: ServiceProxy,
+    service_proxy: Client,
     fail_gracefully=False,
     timeout: float = 5,
     method_name: str = "say_hello",

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,32 @@
+import pytest
+from nameko import config
+from nameko.rpc import RpcProxy, rpc
+from nameko.testing.services import entrypoint_hook
+
+from nameko_chassis.health import is_service_responsive
+
+
+@pytest.fixture(autouse=True)
+def rabbit_config():
+    with config.patch({"AMQP_URI": "pyamqp://localhost:5672"}):
+        yield
+
+
+class MyService:
+    name = "my_service"
+    my_service = RpcProxy(name)
+
+    @rpc
+    def up(self):
+        return "ok"
+
+    @rpc
+    def is_responsive(self):
+        return is_service_responsive(self.my_service, method_name="up")
+
+
+def test_is_service_responsive(container_factory):
+    container = container_factory(MyService)
+    container.start()
+    with entrypoint_hook(container, "is_responsive") as hook:
+        assert hook() is True


### PR DESCRIPTION
This commit adds a happy-path test case to avoid such an obvious mistake
in the future.

Fixes #14.